### PR TITLE
fix: CODEOWNERS の構文を修正

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-- @resessh
+* @resessh


### PR DESCRIPTION
## 概要

CODEOWNERS が Markdown のリスト記法 (`- @resessh`) のままで、CODEOWNERS ファイルとして無効になっていた。GitHub は `-` をパターン、`@resessh` をオーナーとして解釈するため、実際のファイルに対するコードオーナーが設定されていない状態だった。

全ファイルを対象とする `* @resessh` に修正する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)